### PR TITLE
Target JVM 1.7 for compilation.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :java-source-paths ["java/src" "java/test"]
+  :javac-options ["-source" "1.7" "-target" "1.7"]
   :dependencies [[baldr "0.1.1"]]
   :profiles {:dev
              {:dependencies [[criterium "0.4.3"]


### PR DESCRIPTION
We use these classes in systems that run on jvm 7 (e.g. our spark
clusters), we need to ensure they can run there. These will still run on
JVM 8  if necessary, so should be low risk.
